### PR TITLE
Refactor/button structure

### DIFF
--- a/ROS/interfaces/msg/Buttons.msg
+++ b/ROS/interfaces/msg/Buttons.msg
@@ -1,2 +1,7 @@
 # Contains all buttons needed
-bool autonomy_enable
+# Each bool represents a button state
+# Format: button_<category>_<function>
+
+bool button_control_autonomy_enable
+bool button_nav_emergency_stop
+bool button_arm_grip_toggle

--- a/ROS/rs_package/launch/rs_launch.xml
+++ b/ROS/rs_package/launch/rs_launch.xml
@@ -34,7 +34,7 @@
                 <remap from="/twist_plus" to="/rs/twist_plus"/>
             </node>
 
-            <node pkg="rs_package" exec="separate_twistplus" name="shit">
+                <node pkg="rs_package" exec="separate_twistplus" name="twist_separator">
                 <remap from="/twist_plus" to="/rs/twist_plus"/>
                 <remap from="/cmd_vel" to="/turtle1/cmd_vel"/>
                 <remap from="/buttons" to="/rs/buttons"/>

--- a/ROS/rs_package/rs_package/skid_steer.py
+++ b/ROS/rs_package/rs_package/skid_steer.py
@@ -117,8 +117,9 @@ class ControllerInterpreter(Node):
             if button_name:  # Skip empty mappings
                 # Construct the full variable name
                 full_button_name = f'button_{button_name}'
-                # Set the button state using dynamic attribute access
-                setattr(output.buttons, full_button_name, 
+                if hasattr(output.buttons, full_button_name):
+                    # Set the button state using dynamic attribute access
+                    setattr(output.buttons, full_button_name, 
                         input.buttons[buttons.index(button_name)] == 1)
         return output
     

--- a/ROS/rs_package/rs_package/skid_steer.py
+++ b/ROS/rs_package/rs_package/skid_steer.py
@@ -26,21 +26,21 @@ class ControllerInterpreter(Node):
             '',                 # Right Trigger (R2)
         ]
         button_map = [
-            'autonomy_enable',  # A (X)
-            '',                 # B (◯)
-            '',                 # X (□)
-            '',                 # Y (△)
-            '',                 # Menu
-            '',                 # Home
-            '',                 # Start
-            '',                 # Left Stick
-            '',                 # Right Stick
-            '',                 # Left Bumper (L1)
-            '',                 # Right Bumper (R1)
-            '',                 # D-Pad Up
-            '',                 # D-Pad Down
-            '',                 # D-Pad Left
-            '',                 # D-Pad Right
+            'control_autonomy_enable',  # A (X)
+            '',                         # B (◯)
+            '',                         # X (□)
+            '',                         # Y (△)
+            '',                         # Menu
+            '',                         # Home
+            '',                         # Start
+            '',                         # Left Stick
+            '',                         # Right Stick
+            '',                         # Left Bumper (L1)
+            '',                         # Right Bumper (R1)
+            '',                         # D-Pad Up
+            '',                         # D-Pad Down
+            '',                         # D-Pad Left
+            '',                         # D-Pad Right
         ]
 
         # Don't send many null packets (reduce bandwidth usage)
@@ -112,9 +112,14 @@ class ControllerInterpreter(Node):
     # Prepares Button part of TwistPlus
     def set_buttons(self, input: Joy, output: TwistPlus, 
                     buttons: list[str]) -> TwistPlus:
-        # TODO: implement a better way than setting buttons one at a time
-        output.buttons.autonomy_enable = input.buttons[buttons.index('autonomy_enable')] == 1
-
+        # Loop through all button mappings
+        for button_name in buttons:
+            if button_name:  # Skip empty mappings
+                # Construct the full variable name
+                full_button_name = f'button_{button_name}'
+                # Set the button state using dynamic attribute access
+                setattr(output.buttons, full_button_name, 
+                        input.buttons[buttons.index(button_name)] == 1)
         return output
     
     # Goes through every element in the Joy topic (other than timing)
@@ -124,8 +129,11 @@ class ControllerInterpreter(Node):
             for j in [i.x, i.y, i.z]:
                 if abs(j) >= 0.05:
                     return False
-        if msg.buttons.autonomy_enable:
-            return False
+        # Check all button attributes
+        for attr in dir(msg.buttons):
+            if attr.startswith('button_'):  # Only check button states
+                if getattr(msg.buttons, attr):
+                    return False
         return True
 
 def main(args=None):


### PR DESCRIPTION
Changed button naming conventions to `button_<category>_<function>`, for example: `button_control_autonomy_enable`. This allows for code similar to the following 
```python
for attr in dir(msg.buttons):
    if attr.startswith('button_'):  # Only check button states
        if getattr(msg.buttons, attr):
            return False
```
`dir(msg.buttons)` gets all attributes of `msg.buttons`, if the attribute starts with our prefix, then we can do stuff on the attribute